### PR TITLE
Configuration hooks

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,35 @@
 import { HubConnectionBuilder, IHttpConnectionOptions } from '@microsoft/signalr';
 
 export interface SignalRConfig {
+	/** The url of the hub to connect to */
 	url: string;
+
+	/** Callback to trigger when the connection is lost */
 	disconnected?: () => void;
+
+	/** Callback to trigger when the connection is reestablished */
 	reconnected?: () => void;
+
+	/**
+	 * Function returning either the an access token to pass to every
+	 * command or a promise that returns the token
+	 * @example
+	 * accessTokenFactory: () => '<my-access-token>'
+	 * @example
+	 * accessTokenFactory: authService.getAccessToken */
 	accessTokenFactory?: () => string | Promise<string>;
+
+	/**
+	 * Hook to modify the connection build before the connect is built
+	 * @param builder The connection builder
+	 * @param options The connection builder options
+	 * @example
+	 * prebuild(builder: HubConnectionBuilder) {
+	 *   builder.configureLogging(LogLevel.Information)
+	 * }
+	 */
 	prebuild?: (builder: HubConnectionBuilder, options: IHttpConnectionOptions) => void;
+
+	/** When true, the connect will automatically attempt to reconnect */
 	automaticReconnect?: boolean;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,9 @@
+import { HubConnectionBuilder } from '@microsoft/signalr';
+
 export interface SignalRConfig {
 	url: string;
 	disconnected?: () => void;
 	accessTokenFactory?: () => string | Promise<string>;
+	onBeforeBuild?: (builder: HubConnectionBuilder) => void;
 	automaticReconnect?: boolean;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,10 @@
-import { HubConnectionBuilder } from '@microsoft/signalr';
+import { HubConnectionBuilder, IHttpConnectionOptions } from '@microsoft/signalr';
 
 export interface SignalRConfig {
 	url: string;
 	disconnected?: () => void;
 	reconnected?: () => void;
 	accessTokenFactory?: () => string | Promise<string>;
-	onBeforeBuild?: (builder: HubConnectionBuilder) => void;
+	prebuild?: (builder: HubConnectionBuilder, options: IHttpConnectionOptions) => void;
 	automaticReconnect?: boolean;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,7 @@
-import { HubConnectionBuilder, IHttpConnectionOptions } from '@microsoft/signalr';
+import {
+	HubConnectionBuilder,
+	IHttpConnectionOptions
+} from '@microsoft/signalr';
 
 export interface SignalRConfig {
 	/** The url of the hub to connect to */
@@ -28,7 +31,10 @@ export interface SignalRConfig {
 	 *   builder.configureLogging(LogLevel.Information)
 	 * }
 	 */
-	prebuild?: (builder: HubConnectionBuilder, options: IHttpConnectionOptions) => void;
+	prebuild?: (
+		builder: HubConnectionBuilder,
+		options: IHttpConnectionOptions
+	) => void;
 
 	/** When true, the connect will automatically attempt to reconnect */
 	automaticReconnect?: boolean;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,6 +4,7 @@ import { SignalRService } from './service';
 import { SignalRSymbol } from './symbols';
 import { HubConnectionBuilder } from '@microsoft/signalr';
 
+/** The SignalR Plugin for Vue JS */
 export const VueSignalR = {
 	install(app: App, options: SignalRConfig) {
 		const service = new SignalRService(options, new HubConnectionBuilder());
@@ -14,6 +15,7 @@ export const VueSignalR = {
 	}
 };
 
+/** Inject the SignalR service */
 export function useSignalR() {
 	const signalr = inject(SignalRSymbol);
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -9,7 +9,7 @@ import { HubEventToken, HubCommandToken } from './tokens';
 type Action = () => void;
 
 export class SignalRService {
-	private connection: HubConnection;
+	public readonly connection: HubConnection;
 	private connected = false;
 
 	private invokeQueue: Action[] = [];

--- a/src/service.ts
+++ b/src/service.ts
@@ -27,10 +27,11 @@ export class SignalRService {
 			connOptions.accessTokenFactory = options.accessTokenFactory;
 		}
 
+		if (options.prebuild) options.prebuild(connectionBuilder, connOptions);
+
 		connectionBuilder.withUrl(options.url, connOptions);
 
 		if (options.automaticReconnect) connectionBuilder.withAutomaticReconnect();
-		if (options.onBeforeBuild) options.onBeforeBuild(connectionBuilder);
 
 		this.connection = connectionBuilder.build();
 		this.connection.onreconnected(() => this.reconnect());

--- a/src/service.ts
+++ b/src/service.ts
@@ -27,6 +27,7 @@ export class SignalRService {
 
 		connectionBuilder.withUrl(options.url, connOptions);
 		if (options.automaticReconnect) connectionBuilder.withAutomaticReconnect();
+		if (options.onBeforeBuild) options.onBeforeBuild(connectionBuilder);
 		this.connection = connectionBuilder.build();
 		this.connection.onclose(() => this.fail());
 	}

--- a/src/service.ts
+++ b/src/service.ts
@@ -9,8 +9,13 @@ import { HubEventToken, HubCommandToken } from './tokens';
 
 type Action = () => void;
 
+/**
+ * A service to integrate SignalR with VueJS
+ */
 export class SignalRService {
+	/** The current SignalR connection object */
 	public readonly connection: HubConnection;
+
 	private initiated = false;
 	private connected = ref(false);
 
@@ -39,6 +44,7 @@ export class SignalRService {
 		this.connection.onclose(() => this.fail());
 	}
 
+	/** Start the connection; called automatically when the plugin is registered */
 	init() {
 		this.connection
 			.start()
@@ -60,6 +66,7 @@ export class SignalRService {
 			});
 	}
 
+	/** Set a callback to trigger when a connection to the hub is successfully established */
 	connectionSuccess(callback: () => void) {
 		if (this.initiated) {
 			callback();
@@ -68,13 +75,22 @@ export class SignalRService {
 		}
 	}
 
-	invoke<T>(target: HubCommandToken<T>, message?: T) {
+	/**
+	 * Send a command to the SignalR hub
+	 * @param target The name or token of the command to send to
+	 * @param message The payload to send to the command
+	 * @returns a promise the resolves with the event returns a value
+	 */
+	invoke<TMessage, TResponse = any>(
+		target: HubCommandToken<TMessage>,
+		message?: TMessage
+	): Promise<TResponse> {
 		const invoke = () =>
 			message
 				? this.connection.invoke(target as string, message)
 				: this.connection.invoke(target as string);
 
-		return new Promise((res, rej) => {
+		return new Promise<TResponse>((res, rej) => {
 			if (this.initiated) {
 				invoke().then(res).catch(rej);
 			} else {
@@ -83,6 +99,11 @@ export class SignalRService {
 		});
 	}
 
+	/**
+	 * Send a command to the SignalR hub without awaiting a response
+	 * @param target The name or token of the command to send to
+	 * @param message The payload to send to the command
+	 */
 	send<T>(target: HubCommandToken<T>, message?: T) {
 		const send = () =>
 			message
@@ -96,10 +117,20 @@ export class SignalRService {
 		}
 	}
 
+	/**
+	 * Subscribe to an event on the hub
+	 * @param target The name or token of the event to listen to
+	 * @param callback The callback to trigger with the hub sends the event
+	 */
 	on<T>(target: HubEventToken<T>, callback: (arg: T) => void) {
 		this.connection.on(target as string, callback);
 	}
 
+	/**
+	 * Unsubscribe from an event on the hub
+	 * @param target The name or token of the event to unsubscribe from
+	 * @param callback The specific callback to unsubscribe. If none is provided, all listeners on the target will be unsubscribed
+	 */
 	off<T>(target: HubEventToken<T>, callback?: (arg: T) => void) {
 		if (callback) {
 			this.connection.off(target as string, callback);
@@ -108,6 +139,7 @@ export class SignalRService {
 		}
 	}
 
+	/** Get a reactive connection status */
 	getConnectionStatus() {
 		return this.connected;
 	}

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,5 +1,6 @@
 import { SignalRService } from './service';
 import { InjectionKey } from 'vue';
 
+/** The injection key for the SignalR service */
 export const SignalRSymbol: InjectionKey<SignalRService> =
 	Symbol('SignalRService');

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,2 +1,5 @@
-export interface HubCommandToken<T> extends String {}
+/** The name of a command to send to the SignalR server */
+export interface HubCommandToken<T> extends String { }
+
+/** The name of an event sent by the SignalR server */
 export interface HubEventToken<T> extends String {}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,5 +1,5 @@
 /** The name of a command to send to the SignalR server */
-export interface HubCommandToken<T> extends String { }
+export interface HubCommandToken<T> extends String {}
 
 /** The name of an event sent by the SignalR server */
 export interface HubEventToken<T> extends String {}


### PR DESCRIPTION
Exposes the connection object (resolves #20) and adds a way to configure the connection builder before builder the connection (resolves #21)